### PR TITLE
fixes #1 ModuleNotFoundError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ Documentation
 """
 
 from distutils.core import setup
-from shaarpy import __version__
+from src.shaarpy import __version__
 
 mod_name = 'shaarpy'
 setup(name=mod_name,


### PR DESCRIPTION
This fixes the ModuleNotFoundError when installing this module. shaarpy
was not found due to race condition. In setup() the src path is
declared, but the import line is above that setup and thus cannot be
found before.